### PR TITLE
Disable man-db auto updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## revdeprun 0.3.0
+
+### Improvements
+
+- Disable `man-db` auto updates before calling apt-based installation steps
+  to reduce potential setup overhead (#9).
+
 ## revdeprun 0.2.0
 
 ### Improvements

--- a/src/r_install.rs
+++ b/src/r_install.rs
@@ -40,6 +40,8 @@ fn is_r_already_installed(shell: &Shell, version: &ResolvedRVersion) -> Result<b
 }
 
 fn install_prerequisites(shell: &Shell) -> Result<()> {
+    disable_man_db_auto_update(shell).context("failed to disable man-db auto updates")?;
+
     cmd!(
         shell,
         "sudo env DEBIAN_FRONTEND=noninteractive apt-get update -y -qq"
@@ -60,6 +62,21 @@ fn install_prerequisites(shell: &Shell) -> Result<()> {
     )
     .run()
     .context("apt-get install of revdepcheck dependencies failed")?;
+
+    Ok(())
+}
+
+fn disable_man_db_auto_update(shell: &Shell) -> Result<()> {
+    cmd!(shell, "sudo debconf-communicate")
+        .run()
+        .context("debconf-communicate failed for man-db")?;
+
+    cmd!(
+        shell,
+        "sudo env DEBIAN_FRONTEND=noninteractive dpkg-reconfigure man-db"
+    )
+    .run()
+    .context("dpkg-reconfigure of man-db failed")?;
 
     Ok(())
 }


### PR DESCRIPTION
This PR disables the man-db auto updates when finishing `apt` installations to avoid **potential** speed pitfalls (stuck in a "processing triggers for man-db" step).

xref: https://github.com/actions/runner-images/issues/10977