### PR TITLE
Set `revdep_check(bioc = FALSE)`

### DIFF
--- a/src/revdep.rs
+++ b/src/revdep.rs
@@ -223,7 +223,7 @@ fn build_revdep_run_script(repo_path: &Path, num_workers: usize) -> Result<Strin
 
 Sys.setenv(R_BIOC_VERSION = as.character(BiocManager::version()))
 revdepcheck::revdep_reset()
-revdepcheck::revdep_check(num_workers = {workers}, quiet = FALSE)
+revdepcheck::revdep_check(num_workers = {workers}, bioc = FALSE, quiet = FALSE)
 "#
     );
 


### PR DESCRIPTION
Closes #17 

This PR sets `revdep_check(bioc = FALSE)` to follow the default behavior of `revdepcheck::cloud_check()` of **not** checking Bioconductor packages by default, as CRAN is the sole focus and primary concern in this context.

While we still keep setting `options(BioC_mirror)` and `R_BIOC_VERSION` environment variable in case queries are being made to Bioconductor repos.