### PR TITLE
Set `revdep_check(quiet = TRUE)`

### DIFF
--- a/src/revdep.rs
+++ b/src/revdep.rs
@@ -223,7 +223,7 @@ fn build_revdep_run_script(repo_path: &Path, num_workers: usize) -> Result<Strin
 
 Sys.setenv(R_BIOC_VERSION = as.character(BiocManager::version()))
 revdepcheck::revdep_reset()
-revdepcheck::revdep_check(num_workers = {workers}, bioc = FALSE, quiet = FALSE)
+revdepcheck::revdep_check(num_workers = {workers}, bioc = FALSE, quiet = TRUE)
 "#
     );
 


### PR DESCRIPTION
Fixes #19 

To suppress the tedious `install.packages()` outputs for the package being checked.