### PR TITLE
Add auto-tuned max connections for Rscript execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+- Launch `Rscript` with an auto-tuned `--max-connections` value based
+  on the CPU core count to avoid potential connection limits during parallel
+  reverse dependency checks on high-CPU instances.
+
 ## revdeprun 1.0.0
 
 ### Significant changes


### PR DESCRIPTION
Fixes #50 

- Implemented `optimal_max_connections` function to calculate the appropriate value for R's `--max-connections` flag based on CPU count.
- Updated `run_revcheck` and `install_reverse_dep_sysreqs` functions to utilize the calculated max connections when launching Rscript.