### PR TITLE
Clarify pak system requirements message

### DIFF
--- a/src/r_install.rs
+++ b/src/r_install.rs
@@ -89,8 +89,8 @@ fn install_prerequisites(shell: &Shell, progress: &Progress) -> Result<()> {
 
     run_command(
         progress,
-        "Installing revdep dependencies",
-        "revdep dependencies installed",
+        "Installing pak system requirements",
+        "pak system requirements installed",
         cmd!(
             shell,
             "sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y libcurl4-openssl-dev libssl-dev"


### PR DESCRIPTION
Clarify the terminal message that `libcurl4-openssl-dev` and `libssl-dev` are system requirements required by {pak}.

They are required by {curl} which needs to be compiled when installing {pak}.