### PR TITLE
Clarify supported Ubuntu versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ restart your shell.
 
 Currently, this tool is designed for Ubuntu-based systems and requires:
 
-- Operating system: Ubuntu 22.04 or newer.
+- Operating system: Ubuntu 22.04 LTS, 24.04 LTS, and future LTS releases.
 - Version control: Git on `PATH`.
 - Network access: To download R, R packages, and repository metadata.
 - Elevated privileges: `sudo` access for installing R and system requirements.


### PR DESCRIPTION
Only Ubuntu LTS releases (22.04 LTS, 24.04 LTS, and future) are supported since P3M only has binary package repos for 22.04, 24.04, and predictably, 26.04 in the future.