### PR TITLE
Modify `rev_check()` options in `revdep.rs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## revdeprun 1.2.1
+
+### Improvements
+
+- Align the reverse dependency run script options with yihui/crandalf defaults
+  with modifications so `xfun::rev_check()` has sensible browser, compilation,
+  timeout, sampling, and Markdown summary report retention settings.
+
 ## revdeprun 1.2.0
 
 ### Bug fixes

--- a/src/revdep.rs
+++ b/src/revdep.rs
@@ -492,7 +492,16 @@ ensure_installed("xfun")
 ensure_installed("markdown")
 ensure_installed("rmarkdown")
 
-options(xfun.rev_check.summary = TRUE)
+options(
+  browser = "false",
+  install.packages.compile.from.source = "always",
+  xfun.rev_check.compare = TRUE,
+  xfun.rev_check.timeout = 30 * 60,
+  xfun.rev_check.summary = TRUE,
+  xfun.rev_check.sample = Inf,
+  xfun.rev_check.keep_md = TRUE,
+  xfun.rev_check.timeout_total = Inf
+)
 
 package_name <- read.dcf("DESCRIPTION", fields = "Package")[1, 1]
 if (!nzchar(package_name)) {{
@@ -615,7 +624,15 @@ mod tests {
         assert!(script.contains("mc.cores = install_workers"));
         assert!(script.contains("ensure_installed(\"markdown\")"));
         assert!(script.contains("ensure_installed(\"rmarkdown\")"));
-        assert!(script.contains("options(xfun.rev_check.summary = TRUE)"));
+        assert!(script.contains("options("));
+        assert!(script.contains("browser = \"false\""));
+        assert!(script.contains("install.packages.compile.from.source = \"always\""));
+        assert!(script.contains("xfun.rev_check.compare = TRUE"));
+        assert!(script.contains("xfun.rev_check.timeout = 30 * 60"));
+        assert!(script.contains("xfun.rev_check.summary = TRUE"));
+        assert!(script.contains("xfun.rev_check.sample = Inf"));
+        assert!(script.contains("xfun.rev_check.keep_md = TRUE"));
+        assert!(script.contains("xfun.rev_check.timeout_total = Inf"));
         assert!(script.contains("setwd('/tmp/example')"));
         assert!(script.contains("library_dir <- file.path(revdep_dir, \"library\")"));
     }


### PR DESCRIPTION
This PR expands the `options()` for running `xfun::rev_check()` by modifying from yihui/crandalf `.Rprofile` settings.