### PR TITLE
Add monkey patch for `xfun::compare_Rcheck()`

### DIFF
--- a/src/revdep.rs
+++ b/src/revdep.rs
@@ -515,7 +515,7 @@ revdeprun_compare_check <- function(status_only = TRUE, output = '00check_diffs.
         }}
       }}
       # if the check with current CRAN version of package also failed, or the
-      # two statues are the same, chances are we are good to go
+      # two statuses are the same, chances are we are good to go
       s1 <- status_line(f[1])
       if (length(grep('Status: .*\\d+ ERROR', s1)) || identical(s1, status_line(f[2]))) {{
         unlink(d2(d), recursive = TRUE); next


### PR DESCRIPTION
This PR adds a monkey patch version of `xfun::compare_Rcheck()` to fix an issue where the check comparison content is not written into the Markdown output.

We can remove this once https://github.com/yihui/xfun/pull/109 is merged and released.