### PR TITLE
Install `Suggests` dependencies for the package being checked

### DIFF
--- a/src/revdep.rs
+++ b/src/revdep.rs
@@ -402,7 +402,7 @@ ensure_installed("xfun")
 
 # DESCRIPTION parsing helpers ----
 strip_version <- function(entries) {{
-  entries <- gsub('\\s*\\(.*?\\)', '', entries)
+  entries <- gsub("\\s*\\(.*?\\)", "", entries)
   trimws(entries)
 }}
 


### PR DESCRIPTION
This PR improves the logic in `revdep.rs` to also install the `Suggests` dependencies for the package being checked (both CRAN version and dev version) because they are necessary.