### PR TITLE
Normalize revdep library path to absolute path

### DIFF
--- a/src/revdep.rs
+++ b/src/revdep.rs
@@ -628,15 +628,17 @@ fn script_prelude(repo_path: &Path, num_workers: usize) -> String {
 # Prepare workspace directories ----
 setwd({path_literal})
 
-revdep_dir <- file.path("revdep")
+revdep_dir <- file.path(getwd(), "revdep")
 dir.create(revdep_dir, recursive = TRUE, showWarnings = FALSE)
+revdep_dir <- normalizePath(revdep_dir, winslash = "/", mustWork = TRUE)
 
 # Configure library paths ----
 library_dir <- file.path(revdep_dir, "library")
 dir.create(library_dir, recursive = TRUE, showWarnings = FALSE)
+library_dir <- normalizePath(library_dir, winslash = "/", mustWork = TRUE)
 
 Sys.setenv(R_LIBS_USER = library_dir)
-.libPaths(c(library_dir, .libPaths()))
+.libPaths(unique(c(library_dir, .libPaths())))
 
 # Configure parallelism ----
 install_workers <- {workers}
@@ -726,8 +728,13 @@ mod tests {
         assert!(script.contains("dependency_map <- tools::package_dependencies("));
         assert!(script.contains("recursive = FALSE"));
         assert!(script.contains("repos = binary_repo"));
+        assert!(script.contains("revdep_dir <- file.path(getwd(), \"revdep\")"));
+        assert!(script.contains(
+            "revdep_dir <- normalizePath(revdep_dir, winslash = \"/\", mustWork = TRUE)"
+        ));
         assert!(script.contains("Skipping packages not available from repository"));
         assert!(script.contains("setwd('/tmp/example')"));
+        assert!(script.contains(".libPaths(unique(c(library_dir, .libPaths())))"));
     }
 
     #[test]
@@ -752,6 +759,9 @@ mod tests {
         assert!(script.contains("xfun.rev_check.timeout_total = Inf"));
         assert!(script.contains("setwd('/tmp/example')"));
         assert!(script.contains("library_dir <- file.path(revdep_dir, \"library\")"));
+        assert!(script.contains(
+            "library_dir <- normalizePath(library_dir, winslash = \"/\", mustWork = TRUE)"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #89 

This PR normalizes revdep library path to absolute path so the generated scripts always point to the absolute library directory, preventing `xfun::rev_check()` from losing sight of preinstalled binaries.

- In `src/revdep.rs:631-641` the prelude now builds `revdep_dir/library_dir` via `getwd()` + `normalizePath()` and feeds a deduped `.libPaths(...)`, keeping the shared lib visible even after working-directory changes.
- Updated the companion assertions in `src/revdep.rs:731-760` to lock in the new fragments.

---

## Root Cause

`script_prelude()` wires `.libPaths()` with the relative directory `revdep/library`; see src/revdep.rs:629-639. When `xfun::rev_check()` spins up a check it changes the working directory (e.g. into `revdep/checks/<pkg>`), so that relative entry now resolves to `revdep/checks/<pkg>/revdep/library`, which does not contain your pre-installed binaries. From that point the installer cannot see dplyr, triggering the "there is no package called 'dplyr'" error even though it exists back at `/root/gsDesign/revdep/library`.

## Why manual runs work

In your manual session you called `setwd()` and then added an absolute library path, so `.libPaths()` kept pointing at `/root/gsDesign/revdep/library` regardless of any later `setwd()` calls. The CLI-generated script never normalized the path, so it breaks as soon as `rev_check()` moves around.

## Fix

Make the prelude hand R an absolute path before adding it to .`libPaths()`, e.g.

```r
setwd(<repo>)
revdep_dir <- normalizePath(file.path(getwd(), "revdep"), winslash = "/", mustWork = FALSE)
dir.create(revdep_dir, recursive = TRUE, showWarnings = FALSE)

library_dir <- normalizePath(file.path(revdep_dir, "library"), winslash = "/", mustWork = FALSE)
dir.create(library_dir, recursive = TRUE, showWarnings = FALSE)

Sys.setenv(R_LIBS_USER = library_dir)
.libPaths(unique(c(library_dir, .libPaths())))
```

Updating `script_prelude()` once applies to both the install and run scripts, and prevents reverse checks from "losing" the shared library.