### PR TITLE
Remove headless display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@
 
 ### Improvements
 
-- Skip reverse dependency packages that fail to build or are unavailable by
-  appending pak's ignore qualifiers and extend retry attempts for transient
-  download errors during the pre-installation phase.
+- Skip reverse dependency packages that fail to build or are unavailable
+  by appending pak ignore qualifiers during pre-installation.
+  Retry attempts for transient download errors increased from 3 to 5.
+- Revert headless X11 display changes from #97. The `Rscript` command now
+  runs directly as packages that fail to build are skipped automatically.
 
 ## revdeprun 1.4.0
 

--- a/src/r_install.rs
+++ b/src/r_install.rs
@@ -98,17 +98,6 @@ fn install_prerequisites(shell: &Shell, progress: &Progress) -> Result<()> {
         ),
     )?;
 
-    // https://github.com/nanxstats/revdeprun/issues/96
-    run_command(
-        progress,
-        "Installing headless display prerequisites",
-        "Headless display prerequisites installed",
-        cmd!(
-            shell,
-            "sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y xvfb xauth x11-apps tk"
-        ),
-    )?;
-
     Ok(())
 }
 

--- a/src/revdep.rs
+++ b/src/revdep.rs
@@ -321,8 +321,15 @@ pub fn run_revcheck(
     let _dir_guard = shell.push_dir(repo_path);
 
     let install_task = progress.task("Installing revdep dependencies");
-    let install_result = progress
-        .suspend(|| run_rscript_with_virtual_display(shell, &install_path, max_connections));
+    let install_result = progress.suspend(|| {
+        let install_max_connections = max_connections.to_string();
+        cmd!(
+            shell,
+            "Rscript --vanilla --max-connections={install_max_connections} {install_path}"
+        )
+        .quiet()
+        .run()
+    });
 
     match install_result {
         Ok(_) => {
@@ -336,32 +343,17 @@ pub fn run_revcheck(
 
     progress.println("Launching xfun::rev_check()...");
     progress.suspend(|| {
-        run_rscript_with_virtual_display(shell, &run_path, max_connections)
-            .context("xfun::rev_check() reported an error")
+        let run_max_connections = max_connections.to_string();
+        cmd!(
+            shell,
+            "Rscript --vanilla --max-connections={run_max_connections} {run_path}"
+        )
+        .quiet()
+        .run()
+        .context("xfun::rev_check() reported an error")
     })?;
 
     Ok(())
-}
-
-fn run_rscript_with_virtual_display(
-    shell: &Shell,
-    script_path: &Path,
-    max_connections: usize,
-) -> Result<()> {
-    let server_args = "-screen 0 1600x900x24 -ac";
-    let max_connections_arg = max_connections.to_string();
-    cmd!(
-        shell,
-        "xvfb-run -a --server-args={server_args} Rscript --vanilla --max-connections={max_connections_arg} {script_path}"
-    )
-    .quiet()
-    .run()
-    .with_context(|| {
-        format!(
-            "failed to execute Rscript under xvfb-run for {}",
-            script_path.display()
-        )
-    })
 }
 
 /// Returns the default library directory created for xfun::rev_check().


### PR DESCRIPTION
This PR reverts #97, to prefer running vanilla `Rscript` directly, since #102 makes pak ignore packages that fail to build (such as gWidgets2tcltk).