### PR TITLE
Increase `xfun.rev_check.download_cores` from 6 to 50

### DIFF
--- a/src/revdep.rs
+++ b/src/revdep.rs
@@ -619,7 +619,7 @@ options(
   browser = "false",
   install.packages.compile.from.source = "always",
   xfun.rev_check.compare = TRUE,
-  xfun.rev_check.download_cores = 6,
+  xfun.rev_check.download_cores = 50,
   xfun.rev_check.timeout = 30 * 60,
   xfun.rev_check.summary = TRUE,
   xfun.rev_check.sample = Inf,
@@ -913,7 +913,7 @@ mod tests {
         assert!(script.contains("browser = \"false\""));
         assert!(script.contains("install.packages.compile.from.source = \"always\""));
         assert!(script.contains("xfun.rev_check.compare = TRUE"));
-        assert!(script.contains("xfun.rev_check.download_cores = 6"));
+        assert!(script.contains("xfun.rev_check.download_cores = 50"));
         assert!(script.contains("xfun.rev_check.timeout = 30 * 60"));
         assert!(script.contains("xfun.rev_check.summary = TRUE"));
         assert!(script.contains("xfun.rev_check.sample = Inf"));


### PR DESCRIPTION
The current value `6` can be a bit conservative... Bumping this to 50 so it's consistent with uv's `concurrent-downloads` default value and much faster when downloading thousands of reverse dependency source tarballs.