### PR TITLE
Release revdeprun 2.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "revdeprun"
-version = "2.1.2"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "revdeprun"
-version = "2.1.2"
+version = "2.2.0"
 edition = "2024"
 description = "Easy reverse dependency checks for R with cloud-ready environment setup"
 license = "MIT"


### PR DESCRIPTION
This PR bumps the version number. The changelog was already updated.