### PR TITLE
Add documentation badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![crates.io version](https://img.shields.io/crates/v/revdeprun)](https://crates.io/crates/revdeprun)
 [![CI tests](https://github.com/nanxstats/revdeprun/actions/workflows/ci.yml/badge.svg)](https://github.com/nanxstats/revdeprun/actions/workflows/ci.yml)
+[![Documentation](https://github.com/nanxstats/revdeprun/actions/workflows/docs.yml/badge.svg)](https://nanx.me/revdeprun/)
+[![docs.rs](https://img.shields.io/docsrs/revdeprun?label=docs.rs)](https://docs.rs/revdeprun/latest/revdeprun/)
 ![License](https://img.shields.io/crates/l/revdeprun)
 
 A command-line tool that automates reverse dependency checking for R packages.


### PR DESCRIPTION
This PR adds a dedicated documentation site badge and a docs.rs badge to `README.md`.