### PR TITLE
Enable ligatures for code elements

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -108,3 +108,9 @@ h4 code {
 .md-typeset table:not([class]) {
     font-size: 0.8rem;
 }
+
+.md-typeset code,
+.md-typeset kbd,
+.md-typeset pre {
+    font-feature-settings: "calt", "liga";
+}


### PR DESCRIPTION
This PR updates `docs/stylesheets/extra.css` to enable coding ligatures so that elements like `::` and `:::` are easier to read on the documentation website.