### PR TITLE
add fallback mapping for os that are unsupported by rhub

### DIFF
--- a/src/r_version.rs
+++ b/src/r_version.rs
@@ -102,7 +102,16 @@ fn linux_platform() -> Result<String> {
         .cloned()
         .ok_or_else(|| anyhow::anyhow!("missing VERSION_ID in /etc/os-release"))?;
 
+    let (id, version) = fallback_platform(&id, &version);
     Ok(format!("linux-{id}-{version}"))
+}
+
+/// Maps unsupported distro versions to their closest supported version.
+fn fallback_platform<'a>(id: &'a str, version: &'a str) -> (&'a str, &'a str) {
+    match (id, version) {
+        ("debian", "13") => ("debian", "12"),
+        _ => (id, version),
+    }
 }
 
 fn parse_os_release(contents: &str) -> HashMap<String, String> {


### PR DESCRIPTION
Closes #159 

Apparently the rhub API only supports debian up to [debian 12](https://api.r-hub.io/rversions/#/paths/~1resolve~1:version~1:os~1:arch/get)

This PR adds a list of fallback version for these cases. Definitely not the most elegant option but it seemed viable.