### PR TITLE
Add Ubuntu 26.04 LTS support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## revdeprun (development version)
 
+### New features
+
+- Add support for Ubuntu 26.04 LTS (Resolute Raccoon), including R installation
+  via the R Hub versions API and pre-built R package binaries from the
+  Posit Public Package Manager repository (#167).
+
 ### Bug fixes
 
 - Correct `--skip-r-install` behavior to make it truly bypass R version

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ restart your shell.
 
 Currently, this tool is designed for Ubuntu-based systems and requires:
 
-- Operating system: Ubuntu 22.04 LTS, 24.04 LTS, and future LTS releases.
+- Operating system: Ubuntu 22.04, 24.04, 26.04, and future LTS releases.
 - Version control: Git on `PATH`.
 - Network access: To download R, R packages, and repository metadata.
 - Elevated privileges: `sudo` access for installing R and system requirements.

--- a/docs/guide/install.md
+++ b/docs/guide/install.md
@@ -6,7 +6,7 @@ icon: lucide/download
 
 revdeprun is built for Ubuntu LTS cloud instances. You will need:
 
-- Ubuntu 22.04 or 24.04 (or newer LTS).
+- Ubuntu 22.04, 24.04, 26.04 (or newer LTS).
 - `git` on `PATH`.
 - `sudo` access (for R + system requirements).
 - Internet access (CRAN metadata, R installers, packages).

--- a/src/r_version.rs
+++ b/src/r_version.rs
@@ -208,18 +208,26 @@ mod tests {
     #[test]
     fn parses_os_release() {
         let sample = r#"NAME="Ubuntu"
-VERSION="22.04.4 LTS (Jammy Jellyfish)"
+VERSION="26.04 LTS (Resolute Raccoon)"
 ID=ubuntu
 ID_LIKE=debian
-VERSION_ID="22.04"
-PRETTY_NAME="Ubuntu 22.04.4 LTS"
-VERSION_CODENAME=jammy
-UBUNTU_CODENAME=jammy
+VERSION_ID="26.04"
+PRETTY_NAME="Ubuntu 26.04 LTS"
+VERSION_CODENAME=resolute
+UBUNTU_CODENAME=resolute
 "#;
 
         let pairs = parse_os_release(sample);
         assert_eq!(pairs.get("ID").map(String::as_str), Some("ubuntu"));
-        assert_eq!(pairs.get("VERSION_ID").map(String::as_str), Some("22.04"));
+        assert_eq!(pairs.get("VERSION_ID").map(String::as_str), Some("26.04"));
+    }
+
+    #[test]
+    fn builds_ubuntu_26_04_version_url() {
+        assert_eq!(
+            version_url("devel", "linux-ubuntu-26.04", Some("x86_64")),
+            format!("{API_ENDPOINT}/devel/linux-ubuntu-26.04/x86_64")
+        );
     }
 
     #[test]
@@ -299,5 +307,29 @@ UBUNTU_CODENAME=jammy
             serde_json::from_str::<ApiResponse>(unsupported).unwrap(),
             ApiResponse::Error(_)
         ));
+    }
+
+    #[test]
+    fn parses_ubuntu_26_04_api_response() {
+        let response = r#"{
+            "ppm-binaries": true,
+            "ppm-binary-url": "resolute",
+            "version": "4.7.0",
+            "nickname": "Unsuffered Consequences",
+            "type": "devel",
+            "url": "https://cdn.posit.co/r/ubuntu-2604/pkgs/r-devel_1_amd64.deb",
+            "date": null
+        }"#;
+
+        let parsed = serde_json::from_str::<ApiResponse>(response).unwrap();
+        let ApiResponse::Resolved(resolved) = parsed else {
+            panic!("Ubuntu 26.04 response should resolve successfully");
+        };
+        assert_eq!(resolved.version, "4.7.0");
+        assert_eq!(resolved.kind.as_deref(), Some("devel"));
+        assert_eq!(
+            resolved.url,
+            "https://cdn.posit.co/r/ubuntu-2604/pkgs/r-devel_1_amd64.deb"
+        );
     }
 }

--- a/src/revdep.rs
+++ b/src/revdep.rs
@@ -835,12 +835,17 @@ mod tests {
         let path = Path::new("/tmp/example");
         let pkgdepends_patch_path = Path::new("/tmp/patch-pkgdepends.R");
         let max_connections = util::optimal_max_connections(8);
-        let script =
-            build_revdep_install_script(path, 8, max_connections, "noble", pkgdepends_patch_path)
-                .expect("script must build");
+        let script = build_revdep_install_script(
+            path,
+            8,
+            max_connections,
+            "resolute",
+            pkgdepends_patch_path,
+        )
+        .expect("script must build");
         assert!(script.contains("https://packagemanager.posit.co/cran/__linux__/%s/latest"));
         assert!(script.contains(
-            "sprintf(\"https://packagemanager.posit.co/cran/__linux__/%s/latest\", 'noble')"
+            "sprintf(\"https://packagemanager.posit.co/cran/__linux__/%s/latest\", 'resolute')"
         ));
         assert!(script.contains("install.packages(\n      \"pak\""));
         assert!(script.contains("pak::pkg_install("));
@@ -928,12 +933,12 @@ mod tests {
     fn parses_codename_from_os_release() {
         let contents = r#"
 NAME="Ubuntu"
-VERSION="24.04 LTS (Noble Nimbus)"
-VERSION_CODENAME=noble
-UBUNTU_CODENAME=noble
+VERSION="26.04 LTS (Resolute Raccoon)"
+VERSION_CODENAME=resolute
+UBUNTU_CODENAME=resolute
 "#;
         let codename = ubuntu_codename_from_os_release(contents);
-        assert_eq!(codename.as_deref(), Some("noble"));
+        assert_eq!(codename.as_deref(), Some("resolute"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #163 

This PR (formally) adds support for Ubuntu 26.04 LTS (Resolute Raccoon).

- Add regression coverage for generating and parsing Ubuntu 26.04 R Hub API responses.
- Update the P3M binary repository tests to use the `resolute` repository.
- Update the README and installation guide to list support through Ubuntu 26.04.
- Remove outdated Ubuntu 24.04/Noble nomenclature.

Note that the existing platform detection and repository selection logic is release agnostic: R Hub uses the detected Ubuntu version, while P3M uses the detected Ubuntu codename.

## Upstream availability

- R Hub: `https://api.r-hub.io/rversions/resolve/devel/linux-ubuntu-26.04`
- Posit Public Package Manager: `https://packagemanager.posit.co/cran/__linux__/resolute/latest`