### PR TITLE
Prevent P3M rate limit failures during large revdep checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /target
 
-/.claude/
+/reference/
 
 # Zensical site
 pyproject.toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 - Replace the hard-coded Debian 13 to Debian 12 mapping from #160 with live
   fallback probing. Unsupported future Debian releases now fall back one
   release at a time until the R Hub API returns a compatible installer (#162).
+- Prevent [P3M rate limit failures](https://forum.posit.co/t/210701) during
+  large-scale reverse dependency checks by sharing a request budget between
+  pak binary downloads and xfun source tarball downloads. Downloads pause
+  after 1,800 P3M package requests and resume after a 5-minute cooldown (#168).
 
 ## revdeprun 2.2.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Add support for Ubuntu 26.04 LTS (Resolute Raccoon), including R installation
   via the R Hub versions API and pre-built R package binaries from the
-  Posit Public Package Manager repository (#167).
+  Posit Public Package Manager repository (#163).
 
 ### Bug fixes
 
@@ -19,7 +19,7 @@
 - Prevent [P3M rate limit failures](https://forum.posit.co/t/210701) during
   large-scale reverse dependency checks by sharing a request budget between
   pak binary downloads and xfun source tarball downloads. Downloads pause
-  after 1,800 P3M package requests and resume after a 5-minute cooldown (#168).
+  after 1,800 P3M package requests and resume after a 5-minute cooldown (#161).
 
 ## revdeprun 2.2.3
 

--- a/assets/patch-pkgdepends.R
+++ b/assets/patch-pkgdepends.R
@@ -246,6 +246,10 @@ pkgdepends_patch_parallel_install <- function(p3m_state_file) {
 
       if (length(p3m_pending) && capacity == 0L) {
         wait <- p3m_rate_limit_wait_seconds(state)
+        cli::cli_alert_info(sprintf(
+          "P3M request budget reached; resuming downloads in %.0f seconds.",
+          ceiling(wait)
+        ))
         return(
           # pkgdepends wraps pkgcache's private delay() as async_delay().
           async_delay(wait)$then(function(value) {

--- a/assets/patch-pkgdepends.R
+++ b/assets/patch-pkgdepends.R
@@ -247,7 +247,8 @@ pkgdepends_patch_parallel_install <- function(p3m_state_file) {
       if (length(p3m_pending) && capacity == 0L) {
         wait <- p3m_rate_limit_wait_seconds(state)
         return(
-          delay(wait)$then(function(value) {
+          # pkgdepends wraps pkgcache's private delay() as async_delay().
+          async_delay(wait)$then(function(value) {
             p3m_rate_limit_reset(p3m_state_file)
             run_next_batch()
           })

--- a/assets/patch-pkgdepends.R
+++ b/assets/patch-pkgdepends.R
@@ -1,4 +1,4 @@
-# Monkey patches for the {pkgdepends} install scheduler
+# Monkey patches for the {pkgdepends} install scheduler and P3M downloads
 #
 # Motivation:
 # - pkgdepends::install_package_plan() starts only one new task per event-loop
@@ -6,18 +6,90 @@
 #   between polls (common with small binary packages).
 # - stop_task_install() updates deps_left for *all* packages on every install,
 #   which can be costly for very large plans even when only source builds need it.
+# - Posit Public Package Manager (P3M) limits clients to roughly 2,000 requests
+#   per five minutes. Both pak and xfun can exceed this during large revchecks.
 
-pkgdepends_patch_parallel_install <- function() {
+P3M_REQUEST_LIMIT <- 1800L
+P3M_WINDOW_SECONDS <- 5 * 60 + 5
+
+p3m_rate_limit_is_url <- function(urls) {
+  any(grepl(
+    "^https?://packagemanager[.]posit[.]co(/|$)",
+    urls,
+    ignore.case = TRUE
+  ), na.rm = TRUE)
+}
+
+p3m_rate_limit_default_state <- function() {
+  list(used = 0L, last_completed = NA_real_)
+}
+
+p3m_rate_limit_read_state <- function(state_file) {
+  state <- tryCatch(readRDS(state_file), error = function(err) NULL)
+  if (
+    !is.list(state) ||
+      length(state$used) != 1L ||
+      length(state$last_completed) != 1L ||
+      !is.numeric(state$used) ||
+      !is.numeric(state$last_completed) ||
+      is.na(state$used) ||
+      state$used < 0L ||
+      state$used > P3M_REQUEST_LIMIT
+  ) {
+    return(p3m_rate_limit_default_state())
+  }
+
+  state$used <- as.integer(state$used)
+  state$last_completed <- as.numeric(state$last_completed)
+  age <- as.numeric(Sys.time()) - state$last_completed
+  if (!is.finite(age) || age >= P3M_WINDOW_SECONDS) {
+    p3m_rate_limit_default_state()
+  } else {
+    state
+  }
+}
+
+p3m_rate_limit_write_state <- function(state_file, state) {
+  saveRDS(state, state_file)
+  invisible(state)
+}
+
+p3m_rate_limit_wait_seconds <- function(state) {
+  if (state$used < P3M_REQUEST_LIMIT) {
+    return(0)
+  }
+  max(
+    0,
+    P3M_WINDOW_SECONDS - (as.numeric(Sys.time()) - state$last_completed)
+  )
+}
+
+p3m_rate_limit_reset <- function(state_file) {
+  p3m_rate_limit_write_state(state_file, p3m_rate_limit_default_state())
+}
+
+p3m_rate_limit_record <- function(state_file, state, requests) {
+  state$used <- as.integer(state$used + requests)
+  state$last_completed <- as.numeric(Sys.time())
+  p3m_rate_limit_write_state(state_file, state)
+}
+
+pkgdepends_patch_parallel_install <- function(p3m_state_file) {
   if (!requireNamespace("pkgdepends", quietly = TRUE)) {
     stop("pkgdepends must be installed.", call. = FALSE)
   }
 
+  p3m_state_file <- normalizePath(p3m_state_file, mustWork = TRUE)
   ns <- asNamespace("pkgdepends")
 
   old <- list(
     install_package_plan = get("install_package_plan", envir = ns),
     stop_task_install = get("stop_task_install", envir = ns),
-    stop_task_build = get("stop_task_build", envir = ns)
+    stop_task_build = get("stop_task_build", envir = ns),
+    pkgplan_async_download_internal = get(
+      "pkgplan_async_download_internal",
+      envir = ns
+    )
   )
 
   patched_install_package_plan <- function(
@@ -109,6 +181,14 @@ pkgdepends_patch_parallel_install <- function() {
   # Put helpers into a dedicated environment so patched functions can find
   # them even if we set their environment to the pkgdepends namespace.
   patch_env <- new.env(parent = ns)
+  patch_env$p3m_state_file <- p3m_state_file
+  patch_env$p3m_rate_limit_is_url <- p3m_rate_limit_is_url
+  patch_env$p3m_rate_limit_read_state <- p3m_rate_limit_read_state
+  patch_env$p3m_rate_limit_write_state <- p3m_rate_limit_write_state
+  patch_env$p3m_rate_limit_wait_seconds <- p3m_rate_limit_wait_seconds
+  patch_env$p3m_rate_limit_reset <- p3m_rate_limit_reset
+  patch_env$p3m_rate_limit_record <- p3m_rate_limit_record
+  patch_env$P3M_REQUEST_LIMIT <- P3M_REQUEST_LIMIT
   patch_env$deps_left_remove_if_needed <- function(state, pkg) {
     need <- which(!state$plan$package_done | !state$plan$build_done)
     if (length(need)) {
@@ -116,6 +196,96 @@ pkgdepends_patch_parallel_install <- function() {
     }
     state
   }
+
+  patched_pkgplan_async_download_internal <- function(
+    self,
+    private,
+    what,
+    which
+  ) {
+    if (any(what$status != "OK")) {
+      stop("Resolution has errors, cannot start downloading")
+    }
+    start <- Sys.time()
+    private$progress_bar <- private$create_progress_bar(what)
+
+    is_p3m <- vapply(
+      what$sources,
+      p3m_rate_limit_is_url,
+      FUN.VALUE = logical(1)
+    )
+    pending <- seq_len(nrow(what))
+    downloads <- vector("list", nrow(what))
+
+    download_one <- function(idx) {
+      force(idx)
+      private$download_res(
+        what[idx, ],
+        which = which,
+        on_progress = function(data) {
+          private$update_progress_bar(idx, "got", data)
+        }
+      )$then(function(value) {
+        private$update_progress_bar(idx, "done", value)
+        value
+      })$catch(
+        error = function(err) private$update_progress_bar(idx, "error", err)
+      )
+    }
+
+    run_next_batch <- NULL
+    run_next_batch <- function() {
+      if (!length(pending)) {
+        return(async_constant(downloads))
+      }
+
+      state <- p3m_rate_limit_read_state(p3m_state_file)
+      p3m_pending <- pending[is_p3m[pending]]
+      other_pending <- pending[!is_p3m[pending]]
+      capacity <- P3M_REQUEST_LIMIT - state$used
+
+      if (length(p3m_pending) && capacity == 0L) {
+        wait <- p3m_rate_limit_wait_seconds(state)
+        return(
+          delay(wait)$then(function(value) {
+            p3m_rate_limit_reset(p3m_state_file)
+            run_next_batch()
+          })
+        )
+      }
+
+      selected_p3m <- head(p3m_pending, capacity)
+      selected <- c(other_pending, selected_p3m)
+      pending <<- setdiff(pending, selected)
+
+      when_all(.list = lapply(selected, download_one))$then(function(values) {
+        downloads[selected] <<- values
+        if (length(selected_p3m)) {
+          p3m_rate_limit_record(
+            p3m_state_file,
+            state,
+            length(selected_p3m)
+          )
+        }
+        run_next_batch()
+      })
+    }
+
+    run_next_batch()$then(function(dls) {
+      what$fulltarget <- vcapply(dls, "[[", "fulltarget")
+      what$fulltarget_tree <- vcapply(dls, "[[", "fulltarget_tree")
+      what$download_status <- vcapply(dls, "[[", "download_status")
+      what$download_error <- lapply(dls, function(x) x$download_error[[1]])
+      what$file_size <- vdapply(dls, "[[", "file_size")
+      what$used_cached_binary <- vlapply(dls, "[[", "used_cached_binary")
+      class(what) <- c("pkgplan_downloads", class(what))
+      attr(what, "metadata")$download_start <- start
+      attr(what, "metadata")$download_end <- Sys.time()
+      what
+    })$finally(function() private$done_progress_bar())
+  }
+
+  environment(patched_pkgplan_async_download_internal) <- patch_env
 
   patched_stop_task_install <- function(state, worker) {
     success <- worker$process$get_exit_status() == 0
@@ -253,6 +423,11 @@ pkgdepends_patch_parallel_install <- function() {
     patched_install_package_plan,
     ns = "pkgdepends"
   )
+  assignInNamespace(
+    "pkgplan_async_download_internal",
+    patched_pkgplan_async_download_internal,
+    ns = "pkgdepends"
+  )
   assignInNamespace("stop_task_install", patched_stop_task_install, ns = "pkgdepends")
   assignInNamespace("stop_task_build", patched_stop_task_build, ns = "pkgdepends")
 
@@ -265,23 +440,129 @@ pkgdepends_unpatch_parallel_install <- function(patch) {
     stop("Not a pkgdepends patch object.", call. = FALSE)
   }
   assignInNamespace("install_package_plan", patch$install_package_plan, ns = "pkgdepends")
+  assignInNamespace(
+    "pkgplan_async_download_internal",
+    patch$pkgplan_async_download_internal,
+    ns = "pkgdepends"
+  )
   assignInNamespace("stop_task_install", patch$stop_task_install, ns = "pkgdepends")
   assignInNamespace("stop_task_build", patch$stop_task_build, ns = "pkgdepends")
   invisible(TRUE)
 }
 
-pak_patch_parallel_install <- function(patch_file) {
+pak_patch_parallel_install <- function(patch_file, p3m_state_file) {
   if (!requireNamespace("pak", quietly = TRUE)) {
     stop("pak must be installed.", call. = FALSE)
   }
   patch_file <- normalizePath(patch_file, mustWork = TRUE)
+  p3m_state_file <- normalizePath(p3m_state_file, mustWork = TRUE)
   pak:::remote(
-    function(patch_file) {
+    function(patch_file, p3m_state_file) {
       source(patch_file, local = TRUE)
-      pkgdepends_patch_parallel_install()
+      pkgdepends_patch_parallel_install(p3m_state_file)
       TRUE
     },
-    list(patch_file = patch_file)
+    list(
+      patch_file = patch_file,
+      p3m_state_file = p3m_state_file
+    )
   )
   invisible(TRUE)
+}
+
+xfun_patch_p3m_downloads <- function(p3m_state_file) {
+  if (!requireNamespace("xfun", quietly = TRUE)) {
+    stop("xfun must be installed.", call. = FALSE)
+  }
+
+  p3m_state_file <- normalizePath(p3m_state_file, mustWork = TRUE)
+  ns <- asNamespace("xfun")
+  original <- get("download_tarball", envir = ns)
+  if (inherits(original, "revdeprun_p3m_patch")) {
+    return(invisible(original))
+  }
+
+  patch_env <- new.env(parent = ns)
+  patch_env$original_download_tarball <- original
+  patch_env$p3m_state_file <- p3m_state_file
+  patch_env$p3m_rate_limit_is_url <- p3m_rate_limit_is_url
+  patch_env$p3m_rate_limit_read_state <- p3m_rate_limit_read_state
+  patch_env$p3m_rate_limit_wait_seconds <- p3m_rate_limit_wait_seconds
+  patch_env$p3m_rate_limit_reset <- p3m_rate_limit_reset
+  patch_env$p3m_rate_limit_record <- p3m_rate_limit_record
+  patch_env$P3M_REQUEST_LIMIT <- P3M_REQUEST_LIMIT
+
+  patched_download_tarball <- function(
+    p,
+    db = available.packages(type = "source"),
+    dir = ".",
+    retry = 3
+  ) {
+    if (!length(p)) {
+      return(original_download_tarball(p, db, dir, retry))
+    }
+
+    repositories <- db[p, "Repository"]
+    expected <- file.path(
+      dir,
+      sprintf("%s_%s.tar.gz", p, db[p, "Version"])
+    )
+    is_p3m <- vapply(
+      repositories,
+      p3m_rate_limit_is_url,
+      FUN.VALUE = logical(1)
+    ) & !file.exists(expected)
+    pending <- seq_along(p)
+    tarballs <- character(length(p))
+
+    while (length(pending)) {
+      state <- p3m_rate_limit_read_state(p3m_state_file)
+      p3m_pending <- pending[is_p3m[pending]]
+      other_pending <- pending[!is_p3m[pending]]
+      capacity <- P3M_REQUEST_LIMIT - state$used
+
+      if (length(p3m_pending) && capacity == 0L) {
+        wait <- p3m_rate_limit_wait_seconds(state)
+        message(sprintf(
+          "P3M request budget reached; resuming downloads in %.0f seconds.",
+          ceiling(wait)
+        ))
+        Sys.sleep(wait)
+        p3m_rate_limit_reset(p3m_state_file)
+        next
+      }
+
+      selected_p3m <- head(p3m_pending, capacity)
+      selected <- c(other_pending, selected_p3m)
+      pending <- setdiff(pending, selected)
+      tarballs[selected] <- original_download_tarball(
+        p[selected],
+        db,
+        dir,
+        retry
+      )
+
+      if (length(selected_p3m)) {
+        p3m_rate_limit_record(
+          p3m_state_file,
+          state,
+          length(selected_p3m)
+        )
+      }
+    }
+
+    tarballs
+  }
+
+  environment(patched_download_tarball) <- patch_env
+  class(patched_download_tarball) <- c(
+    "revdeprun_p3m_patch",
+    class(patched_download_tarball)
+  )
+  assignInNamespace(
+    "download_tarball",
+    patched_download_tarball,
+    ns = "xfun"
+  )
+  invisible(original)
 }

--- a/docs/design/deps.md
+++ b/docs/design/deps.md
@@ -56,4 +56,4 @@ The install script:
   source tarball downloads. Large download sets are processed in batches
   of at most 1,800 P3M packages, with a 5-minute cooldown between full batches,
   to stay below P3M's approximate
-  [2,000 request per 5 minute rate limit](https://forum.posit.co/t/210701).
+  [2,000 request per 5 minutes rate limit](https://forum.posit.co/t/210701).

--- a/docs/design/deps.md
+++ b/docs/design/deps.md
@@ -52,3 +52,8 @@ The install script:
   failing package doesn't take down the entire run.
 - Retries `pak::pkg_install()` failures (network blips happen).
 - Installs into `revdep/library/` by setting `R_LIBS_USER` and `.libPaths()`.
+- Shares a P3M request budget across pak's binary downloads and xfun's
+  source tarball downloads. Large download sets are processed in batches
+  of at most 1,800 P3M packages, with a 5-minute cooldown between full batches,
+  to stay below P3M's approximate
+  [2,000 request per 5 minute rate limit](https://forum.posit.co/t/210701).

--- a/src/revdep.rs
+++ b/src/revdep.rs
@@ -351,18 +351,24 @@ pub fn run_revcheck(
     let codename = detect_ubuntu_codename().context("failed to detect Ubuntu release codename")?;
 
     let pkgdepends_patch_path = write_pkgdepends_patch(workspace)?;
+    let p3m_state = NamedTempFile::new_in(workspace.temp_dir())
+        .context("failed to create P3M rate-limit state file")?;
+    let p3m_state_path = workspace::canonicalized(p3m_state.path())
+        .context("failed to resolve P3M rate-limit state file")?;
     let install_contents = build_revdep_install_script(
         repo_path,
         num_workers,
         max_connections,
         &codename,
         &pkgdepends_patch_path,
+        &p3m_state_path,
     )?;
     let run_contents = build_revdep_run_script(
         repo_path,
         num_workers,
         max_connections,
         &pkgdepends_patch_path,
+        &p3m_state_path,
     )?;
 
     let mut install_script = NamedTempFile::new_in(workspace.temp_dir())
@@ -432,12 +438,14 @@ fn build_revdep_install_script(
     max_connections: usize,
     codename: &str,
     pkgdepends_patch_path: &Path,
+    p3m_state_path: &Path,
 ) -> Result<String> {
     let prelude = script_prelude(
         repo_path,
         num_workers,
         max_connections,
         pkgdepends_patch_path,
+        p3m_state_path,
     );
     let codename_literal = util::r_string_literal(&codename.to_lowercase());
 
@@ -461,7 +469,7 @@ ensure_pak(source_repo)
 
 # Apply pkgdepends parallel patch ----
 source(pkgdepends_patch_path)
-pak_patch_parallel_install(pkgdepends_patch_path)
+pak_patch_parallel_install(pkgdepends_patch_path, p3m_state_path)
 
 # Ensure tooling prerequisites ----
 ensure_installed("xfun")
@@ -579,12 +587,14 @@ fn build_revdep_run_script(
     num_workers: usize,
     max_connections: usize,
     pkgdepends_patch_path: &Path,
+    p3m_state_path: &Path,
 ) -> Result<String> {
     let prelude = script_prelude(
         repo_path,
         num_workers,
         max_connections,
         pkgdepends_patch_path,
+        p3m_state_path,
     );
 
     let script = format!(
@@ -607,12 +617,15 @@ ensure_pak(source_repo)
 
 # Apply pkgdepends parallel patch ----
 source(pkgdepends_patch_path)
-pak_patch_parallel_install(pkgdepends_patch_path)
+pak_patch_parallel_install(pkgdepends_patch_path, p3m_state_path)
 
 # Ensure runtime prerequisites ----
 ensure_installed("xfun")
 ensure_installed("markdown")
 ensure_installed("rmarkdown")
+
+# Apply P3M rate limiting to xfun source downloads ----
+xfun_patch_p3m_downloads(p3m_state_path)
 
 # Configure xfun::rev_check() options ----
 options(
@@ -646,9 +659,11 @@ fn script_prelude(
     num_workers: usize,
     max_connections: usize,
     pkgdepends_patch_path: &Path,
+    p3m_state_path: &Path,
 ) -> String {
     let path_literal = util::r_string_literal(&repo_path.to_string_lossy());
     let pkgdepends_patch_literal = util::r_string_literal(&pkgdepends_patch_path.to_string_lossy());
+    let p3m_state_literal = util::r_string_literal(&p3m_state_path.to_string_lossy());
     let workers = num_workers.max(1);
     let max_connections = max_connections.max(1);
 
@@ -682,6 +697,8 @@ options(
 # Configure pkgdepends patch ----
 pkgdepends_patch_path <- {pkgdepends_patch_literal}
 pkgdepends_patch_path <- normalizePath(pkgdepends_patch_path, winslash = "/", mustWork = TRUE)
+p3m_state_path <- {p3m_state_literal}
+p3m_state_path <- normalizePath(p3m_state_path, winslash = "/", mustWork = TRUE)
 
 # Helpers for package installation ----
 pak_install_retry <- function(pkgs, attempts = 5) {{
@@ -834,6 +851,7 @@ mod tests {
     fn build_install_script_uses_binary_repo() {
         let path = Path::new("/tmp/example");
         let pkgdepends_patch_path = Path::new("/tmp/patch-pkgdepends.R");
+        let p3m_state_path = Path::new("/tmp/p3m-rate-limit.rds");
         let max_connections = util::optimal_max_connections(8);
         let script = build_revdep_install_script(
             path,
@@ -841,6 +859,7 @@ mod tests {
             max_connections,
             "resolute",
             pkgdepends_patch_path,
+            p3m_state_path,
         )
         .expect("script must build");
         assert!(script.contains("https://packagemanager.posit.co/cran/__linux__/%s/latest"));
@@ -856,8 +875,11 @@ mod tests {
         assert!(script.contains("?ignore-build-errors&ignore-unavailable"));
         assert!(script.contains("ensure_pak(source_repo)"));
         assert!(script.contains("pkgdepends_patch_path <- '/tmp/patch-pkgdepends.R'"));
+        assert!(script.contains("p3m_state_path <- '/tmp/p3m-rate-limit.rds'"));
         assert!(script.contains("source(pkgdepends_patch_path)"));
-        assert!(script.contains("pak_patch_parallel_install(pkgdepends_patch_path)"));
+        assert!(
+            script.contains("pak_patch_parallel_install(pkgdepends_patch_path, p3m_state_path)")
+        );
         assert!(script.contains(
             "Parsing package metadata and dependency lists...\\nThis can take a few minutes for large revdep sets."
         ));
@@ -891,9 +913,16 @@ mod tests {
     fn build_run_script_invokes_xfun() {
         let path = Path::new("/tmp/example");
         let pkgdepends_patch_path = Path::new("/tmp/patch-pkgdepends.R");
+        let p3m_state_path = Path::new("/tmp/p3m-rate-limit.rds");
         let max_connections = util::optimal_max_connections(8);
-        let script = build_revdep_run_script(path, 8, max_connections, pkgdepends_patch_path)
-            .expect("script must build");
+        let script = build_revdep_run_script(
+            path,
+            8,
+            max_connections,
+            pkgdepends_patch_path,
+            p3m_state_path,
+        )
+        .expect("script must build");
 
         assert!(script.contains("xfun::rev_check"));
         assert!(script.contains("src = \".\""));
@@ -907,8 +936,12 @@ mod tests {
         assert!(script.contains("pak_install_retry(pkg)"));
         assert!(script.contains("ensure_pak(source_repo)"));
         assert!(script.contains("pkgdepends_patch_path <- '/tmp/patch-pkgdepends.R'"));
+        assert!(script.contains("p3m_state_path <- '/tmp/p3m-rate-limit.rds'"));
         assert!(script.contains("source(pkgdepends_patch_path)"));
-        assert!(script.contains("pak_patch_parallel_install(pkgdepends_patch_path)"));
+        assert!(
+            script.contains("pak_patch_parallel_install(pkgdepends_patch_path, p3m_state_path)")
+        );
+        assert!(script.contains("xfun_patch_p3m_downloads(p3m_state_path)"));
         assert!(script.contains("?ignore-build-errors&ignore-unavailable"));
         assert!(script.contains(&format!("async_http_total_con = {max_connections}")));
         assert!(script.contains("async_http_host_con = 50"));
@@ -927,6 +960,18 @@ mod tests {
         assert!(script.contains(
             "library_dir <- normalizePath(library_dir, winslash = \"/\", mustWork = TRUE)"
         ));
+    }
+
+    #[test]
+    fn pkgdepends_patch_throttles_p3m_downloads_across_pak_and_xfun() {
+        assert!(PKGDEPENDS_PATCH.contains("P3M_REQUEST_LIMIT <- 1800L"));
+        assert!(PKGDEPENDS_PATCH.contains("P3M_WINDOW_SECONDS <- 5 * 60 + 5"));
+        assert!(PKGDEPENDS_PATCH.contains("patched_pkgplan_async_download_internal"));
+        assert!(PKGDEPENDS_PATCH.contains("P3M_REQUEST_LIMIT - state$used"));
+        assert!(PKGDEPENDS_PATCH.contains("p3m_rate_limit_record("));
+        assert!(PKGDEPENDS_PATCH.contains("xfun_patch_p3m_downloads <- function"));
+        assert!(PKGDEPENDS_PATCH.contains("original_download_tarball("));
+        assert!(PKGDEPENDS_PATCH.contains(") & !file.exists(expected)"));
     }
 
     #[test]

--- a/src/revdep.rs
+++ b/src/revdep.rs
@@ -974,6 +974,12 @@ mod tests {
         assert!(PKGDEPENDS_PATCH.contains("xfun_patch_p3m_downloads <- function"));
         assert!(PKGDEPENDS_PATCH.contains("original_download_tarball("));
         assert!(PKGDEPENDS_PATCH.contains(") & !file.exists(expected)"));
+        assert_eq!(
+            PKGDEPENDS_PATCH
+                .matches("P3M request budget reached; resuming downloads in %.0f seconds.")
+                .count(),
+            2
+        );
     }
 
     #[test]

--- a/src/revdep.rs
+++ b/src/revdep.rs
@@ -968,6 +968,8 @@ mod tests {
         assert!(PKGDEPENDS_PATCH.contains("P3M_WINDOW_SECONDS <- 5 * 60 + 5"));
         assert!(PKGDEPENDS_PATCH.contains("patched_pkgplan_async_download_internal"));
         assert!(PKGDEPENDS_PATCH.contains("P3M_REQUEST_LIMIT - state$used"));
+        assert!(PKGDEPENDS_PATCH.contains("async_delay(wait)$then("));
+        assert!(!PKGDEPENDS_PATCH.contains("\n          delay(wait)$then("));
         assert!(PKGDEPENDS_PATCH.contains("p3m_rate_limit_record("));
         assert!(PKGDEPENDS_PATCH.contains("xfun_patch_p3m_downloads <- function"));
         assert!(PKGDEPENDS_PATCH.contains("original_download_tarball("));


### PR DESCRIPTION
Fixes #161 

This PR adds a shared P3M request budget covering both download phases of a reverse dependency check: pak binary downloads and xfun source tarball downloads.

Downloads are limited to batches of at most **1,800** P3M packages. After exhausting the budget, it will print this and wait 5 minutes before resuming:

```
ℹ P3M request budget reached; resuming downloads in 305 seconds.
```

The budget persists across the separate install and check R processes.

## Implementation

- Patch pkgdepends' resolved download planner so dependencies discovered by pak are included in the budget.
- Patch `xfun:::download_tarball()` while preserving its native parallel downloads within each batch.
- Exclude already downloaded xfun tarballs from the request count.
- Retain pak's existing HTTP retries for transient failures.

This leaves headroom below P3M's approximate limit of 2,000 requests per 5 minutes and prevents "Failed to download" errors for packages with thousands of relevant packages to download.