### PR TITLE
Release revdeprun 2.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "revdeprun"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "revdeprun"
-version = "2.3.0"
+version = "2.3.1"
 edition = "2024"
 rust-version = "1.85"
 description = "Easy reverse dependency checks for R with cloud-ready environment setup"


### PR DESCRIPTION
This PR bumps the version number. The changelog has already been updated.